### PR TITLE
[Bugfix] Give 404 HTTP response when accessing invalid image

### DIFF
--- a/CHANGELOG.txt
+++ b/CHANGELOG.txt
@@ -14,6 +14,8 @@ New Features:
 Bugfixes:
     [*] Fix MimeGuesser by leveraging symfony mime component, returning generic
         'application/octet-stream' for unknown file type
+    [*] Fix when accessing non existing image inside archive file, give 404 http
+        error response
 Changes:
     [+] Introducing context API to simplify passing object into child component
     [*] Change menu with icon from fontawesome

--- a/src/Controller/ArchiveController.php
+++ b/src/Controller/ArchiveController.php
@@ -49,10 +49,13 @@ class ArchiveController extends AbstractController
 
         $za = new \ZipArchive();
         $za->open($archivePath);
+        $inputStream = $za->getStream($entryName);
+        if (false === $inputStream) {
+            throw $this->createNotFoundException();
+        }
 
-        $response = new StreamedResponse(function () use ($za, $entryName) {
+        $response = new StreamedResponse(function () use ($inputStream) {
             $outputStream = fopen('php://output', 'wb');
-            $inputStream = $za->getStream($entryName);
 
             stream_copy_to_stream($inputStream, $outputStream);
         });

--- a/tests/Controller/ArchiveControllerTest.php
+++ b/tests/Controller/ArchiveControllerTest.php
@@ -39,4 +39,11 @@ class ArchiveControllerTest extends WebTestCase
 
         $this->assertResponseIsSuccessful();
     }
+
+    public function testLoadInvalidImageFromArchiveGiveErrorResponse()
+    {
+        $this->client->request('GET', '/archive.zip%2Fimage.JPEG');
+
+        $this->assertResponseStatusCodeSame(404);
+    }
 }


### PR DESCRIPTION
This could be typo on url or improper url encoding.