### PR TITLE
Fix: Use natural order to sort archive index

### DIFF
--- a/src/Service/ArchiveReader.php
+++ b/src/Service/ArchiveReader.php
@@ -13,7 +13,10 @@ class ArchiveReader
 
     public function getList(): array
     {
-        return iterator_to_array($this->generateList());
+        $list = iterator_to_array($this->generateList());
+        natsort($list);
+
+        return $list;
     }
 
     private function generateList(): \Traversable

--- a/src/Service/ComicBook.php
+++ b/src/Service/ComicBook.php
@@ -7,7 +7,7 @@ class ComicBook
     /**
      * @param string $pathname Pathname of zip file/comicbook
      *
-     * @return string|false Resolveable image url, or false on failure
+     * @return false|string Resolveable image url, or false on failure
      */
     public function getCover(string $pathname)
     {
@@ -18,14 +18,24 @@ class ComicBook
             return false;
         }
 
-        for ($index = 0; $index < $za->numFiles; ++$index) {
-            $cover = $za->statIndex($index)['name'];
-            $coverPatternExtension = '/.+(jpe?g|png|webp)$/i';
-            if (preg_match($coverPatternExtension, $cover)) {
-                return $cover;
-            }
+        $images = iterator_to_array($this->getImages($za));
+        natsort($images);
+
+        if (count($images) > 0) {
+            return $images[array_key_first($images)];
         }
 
         return false;
+    }
+
+    private function getImages(\ZipArchive $archive): \Generator
+    {
+        for ($index = 0; $index < $archive->numFiles; ++$index) {
+            $cover = $archive->statIndex($index)['name'];
+            $coverPatternExtension = '/.+(jpe?g|png|webp)$/i';
+            if (preg_match($coverPatternExtension, $cover)) {
+                yield $cover;
+            }
+        }
     }
 }


### PR DESCRIPTION
## Changes:
- Fix get cover image by assuming that the first image is the cover (after sorted using natural order)
- Fix inconsistent archive entry index using natural order