### PR TITLE
Test: Add phpunit coverage annotation

### DIFF
--- a/tests/Controller/AssetsControllerTest.php
+++ b/tests/Controller/AssetsControllerTest.php
@@ -4,6 +4,10 @@ namespace App\Tests\Controller;
 
 use Symfony\Bundle\FrameworkBundle\Test\WebTestCase;
 
+/**
+ * @internal
+ * @covers \App\Controller\AssetsController
+ */
 class AssetsControllerTest extends WebTestCase
 {
     private $client;
@@ -15,18 +19,25 @@ class AssetsControllerTest extends WebTestCase
 
     /**
      * @dataProvider assetsProvider
+     *
+     * @param mixed $asset
      */
     public function testGetHeaderOfAssetsFile($asset)
     {
         $this->client->request('GET', $asset);
         $this->assertResponseIsSuccessful();
+
         switch (pathinfo($asset, PATHINFO_EXTENSION)) {
             case 'css':
                 $this->assertResponseHeaderSame('Content-Type', 'text/css');
+
                 break;
+
             case 'js':
                 $this->assertResponseHeaderSame('Content-Type', 'application/javascript');
+
                 break;
+
             default:
                 break;
         }

--- a/tests/Controller/DefaultControllerTest.php
+++ b/tests/Controller/DefaultControllerTest.php
@@ -4,6 +4,12 @@ namespace App\Tests\Controller;
 
 use Symfony\Bundle\FrameworkBundle\Test\WebTestCase;
 
+/**
+ * @internal
+ * @covers \App\Controller\DefaultController
+ * @covers \App\Service\DirectoryListing
+ * @covers \App\Service\PathTool
+ */
 class DefaultControllerTest extends WebTestCase
 {
     private $client;
@@ -15,6 +21,8 @@ class DefaultControllerTest extends WebTestCase
 
     /**
      * @dataProvider imageProvider
+     *
+     * @param mixed $image
      */
     public function testLoadImage($image)
     {

--- a/tests/Controller/NextChapterTest.php
+++ b/tests/Controller/NextChapterTest.php
@@ -5,6 +5,13 @@ namespace App\Tests\Controller;
 use Symfony\Bundle\FrameworkBundle\KernelBrowser;
 use Symfony\Bundle\FrameworkBundle\Test\WebTestCase;
 
+/**
+ * @internal
+ * @covers \App\Controller\DefaultController
+ * @covers \App\Service\DirectoryListing
+ * @covers \App\Service\NextChapterResolver
+ * @covers \App\Service\PathTool
+ */
 class NextChapterTest extends WebTestCase
 {
     private KernelBrowser $client;

--- a/tests/Controller/SearchControllerTest.php
+++ b/tests/Controller/SearchControllerTest.php
@@ -4,6 +4,11 @@ namespace App\Tests\Controller;
 
 use Symfony\Bundle\FrameworkBundle\Test\WebTestCase;
 
+/**
+ * @internal
+ * @covers \App\Controller\SearchController
+ * @covers \App\Service\Search
+ */
 class SearchControllerTest extends WebTestCase
 {
     public function testSearchWithEmptyStringShouldReturnNotFoundResponse()

--- a/tests/Service/ArchiveReaderTest.php
+++ b/tests/Service/ArchiveReaderTest.php
@@ -5,6 +5,11 @@ namespace App\Tests\Service;
 use App\Service\ArchiveReader;
 use PHPUnit\Framework\TestCase;
 
+/**
+ * @internal
+ * @covers \App\Service\ArchiveReader
+ * @covers \App\Service\ComicBook
+ */
 class ArchiveReaderTest extends TestCase
 {
     public function testListingArchiveContent()

--- a/tests/Service/ComicBookTest.php
+++ b/tests/Service/ComicBookTest.php
@@ -5,6 +5,11 @@ namespace App\Tests\Service;
 use App\Service\ComicBook;
 use PHPUnit\Framework\TestCase;
 
+/**
+ * @internal
+ * @covers \App\Service\ComicBook
+ * @covers \App\Service\DirectoryListing
+ */
 class ComicBookTest extends TestCase
 {
     public function testGetCover()

--- a/tests/Service/MimeGuesserTest.php
+++ b/tests/Service/MimeGuesserTest.php
@@ -5,10 +5,17 @@ namespace App\Tests\Service;
 use App\Service\MimeGuesser;
 use PHPUnit\Framework\TestCase;
 
+/**
+ * @internal
+ * @covers \App\Service\MimeGuesser
+ */
 class MimeGuesserTest extends TestCase
 {
     /**
      * @dataProvider filenameWithValidExtension
+     *
+     * @param mixed $filename
+     * @param mixed $mime
      */
     public function testGetValidMimeTypes($filename, $mime)
     {
@@ -18,6 +25,9 @@ class MimeGuesserTest extends TestCase
 
     /**
      * @dataProvider filenameWithUnusualExtension
+     *
+     * @param mixed $filename
+     * @param mixed $mime
      */
     public function testGetMimeTypesReturningGenericMimeTypes($filename, $mime)
     {
@@ -27,7 +37,7 @@ class MimeGuesserTest extends TestCase
 
     public function filenameWithValidExtension()
     {
-        return[
+        return [
             ['/image.jpeg', 'image/jpeg'],
             ['/image.JPG', 'image/jpeg'],
             ['/image.PNG', 'image/png'],

--- a/tests/Service/PathToolTest.php
+++ b/tests/Service/PathToolTest.php
@@ -6,11 +6,13 @@ use App\Service\PathTool;
 use PHPUnit\Framework\TestCase;
 use Symfony\Component\HttpFoundation\RequestStack;
 
+/**
+ * @internal
+ * @covers \App\Service\PathTool
+ */
 class PathToolTest extends TestCase
 {
-    /*
-     * This test is for maintaining code coverage
-     */
+    // This test is for maintaining code coverage
     public function testGetUriWhenRequestStackIsEmpty()
     {
         $requestStack = new RequestStack();

--- a/tests/Service/SearchTest.php
+++ b/tests/Service/SearchTest.php
@@ -5,6 +5,11 @@ namespace App\Tests\Service;
 use App\Service\Search;
 use PHPUnit\Framework\TestCase;
 
+/**
+ * @internal
+ * @covers \App\Service\DirectoryListing
+ * @covers \App\Service\Search
+ */
 class SearchTest extends TestCase
 {
     private $search;


### PR DESCRIPTION
Changes:
- Mark test file as internals
- Fix test file code style with `php-cs-fixer` using `@PhpCsFixer,@Symfony,@PSR2` rules.