### PR TITLE
Bugfix: Handle exception when failed to recognise zip archive

### DIFF
--- a/src/Service/DirectoryListing.php
+++ b/src/Service/DirectoryListing.php
@@ -47,10 +47,13 @@ class DirectoryListing
         }
 
         try {
-            $this->za->open($pathname);
-
-            return 'archive';
+            $isArchive = $this->za->open($pathname);
         } catch (\Exception $exception) {
+            return 'file';
+        }
+
+        if (true === $isArchive) {
+            return 'archive';
         }
 
         return 'file';


### PR DESCRIPTION
This bug caused some file not properly categorized and treated as archive.