### PR TITLE
Build: Enable stimulus bridge on webpack encore

### DIFF
--- a/webpack.config.js
+++ b/webpack.config.js
@@ -15,7 +15,7 @@ Encore.addEntry('app', './assets/index.tsx')
   .setPublicPath('/build')
 
   // enables the Symfony UX Stimulus bridge (used in assets/bootstrap.js)
-  // .enableStimulusBridge('./assets/controllers.json')
+  .enableStimulusBridge('./assets/controllers.json')
 
   // When enabled, Webpack "splits" your files into smaller pieces for greater optimization.
   .splitEntryChunks()


### PR DESCRIPTION
For some reason, webpack complaining that controllers.json is not found when stimulus-bridge is disabled from webpack config. For now just enable it to get rid of this error message.

```shell
 ERROR  Failed to compile with 1 errors                              10:33:16 AM

 error  in ./node_modules/@symfony/stimulus-bridge/controllers.json  10:33:16 AM

Module build failed (from ./node_modules/@symfony/stimulus-bridge/dist/webpack/loader.js):
Error: Your controllers.json file was not found. Be sure to add a Webpack alias from "@symfony/stimulus-bridge/controllers.json" to *your* controllers.json file.
    at createControllersModule (./node_modules/@symfony/stimulus-bridge/dist/webpack/loader.js:37:15)
    at Object.loader (./node_modules/@symfony/stimulus-bridge/dist/webpack/loader.js:107:43)
```