### PR TITLE
CI: Pin PHP-CS-Fixer to version 3.4

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -22,7 +22,7 @@ jobs:
                 uses: shivammathur/setup-php@v2
                 with:
                     php-version: ${{ matrix.php-versions }}
-                    tools: psalm, php-cs-fixer
+                    tools: psalm, php-cs-fixer:3.4
             -   name: Setup NodeJS
                 uses: actions/setup-node@v2
                 with:


### PR DESCRIPTION
Php-CS-Fixer v3.5 require php version 7.4 and later which incompatible with this project that still supporting php 7.2.