### PR TITLE
Fix: Footer title and next link

### DIFF
--- a/src/Twig/AppExtension.php
+++ b/src/Twig/AppExtension.php
@@ -30,13 +30,13 @@ class AppExtension extends AbstractExtension
     {
         return [
             new TwigFilter('is_image', [$this, 'isImage']),
-            new TwigFilter('get_title', [$this, 'getTitleFromUri']),
         ];
     }
 
     public function getFunctions(): array
     {
         return [
+            new TwigFunction('get_title', [$this, 'getTitleFromUri']),
             new TwigFunction('is_image', [$this, 'isImage']),
             new TwigFunction('render_breadcrumbs', [$this, 'renderBreadcrumbs'], ['is_safe' => ['html'], 'needs_environment' => true]),
         ];
@@ -55,8 +55,9 @@ class AppExtension extends AbstractExtension
 
         $decodedUri = urldecode($this->request->getRequestUri());
         $array = preg_split('/\//', $decodedUri, -1, PREG_SPLIT_NO_EMPTY);
+        $dirtyString = array_pop($array);
 
-        return array_pop($array);
+        return explode('?', $dirtyString)[0];
     }
 
     public function renderBreadcrumbs(): ?string

--- a/templates/partial/_next_page.html.twig
+++ b/templates/partial/_next_page.html.twig
@@ -1,8 +1,10 @@
-<div class="mt-2 p-4 font-medium text-center text-lg text-gray-400 border-0 border-t border-dashed border-t-2 border-gray-600">
-  End of:
-  <strong class="font-semibold">
-    <span>{{ app.request.requestUri|get_title|default('Title') }}</span>
-    <span>/</span>
-    <span><a href="{{ app.request.requestUri }}?next" class="underline">Next &raquo;</a></span>
-  </strong>
-</div>
+{% if app.request.get('_route') == 'default' %}
+  <div class="mt-2 p-4 font-medium text-center text-lg text-gray-400 border-0 border-t border-dashed border-t-2 border-gray-600">
+    End of:
+    <strong class="font-semibold">
+      <span class="break-words">{{ get_title()|default('Title') }}</span>
+      <span>/</span>
+      <span><a href="{{ app.request.requestUri|split('?')[0] }}?next" class="underline">Next &raquo;</a></span>
+    </strong>
+  </div>
+{% endif %}


### PR DESCRIPTION
Close #125, #123.

Changes:
- Show footer on `default` route only
- Remove query params from footer title