### PR TITLE
Chore: Update flex recipes

### DIFF
--- a/assets/bootstrap.js
+++ b/assets/bootstrap.js
@@ -4,7 +4,7 @@ import { startStimulusApp } from '@symfony/stimulus-bridge';
 export const app = startStimulusApp(require.context(
     '@symfony/stimulus-bridge/lazy-controller-loader!./controllers',
     true,
-    /\.(j|t)sx?$/
+    /\.[jt]sx?$/
 ));
 
 // register any custom, 3rd party controllers here

--- a/composer.json
+++ b/composer.json
@@ -9,7 +9,7 @@
         "sensio/framework-extra-bundle": "^6.2",
         "symfony/console": "5.4.*",
         "symfony/dotenv": "5.4.*",
-        "symfony/flex": "^1.6",
+        "symfony/flex": "^1.18",
         "symfony/framework-bundle": "5.4.*",
         "symfony/mime": "5.4.*",
         "symfony/runtime": "5.4.*",

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "2888e50a62ac22eb1f8b3158903635c2",
+    "content-hash": "300d8aa02b0f73a5dec51bf2b6f8e516",
     "packages": [
         {
             "name": "doctrine/annotations",
@@ -1605,16 +1605,16 @@
         },
         {
             "name": "symfony/flex",
-            "version": "v1.17.6",
+            "version": "v1.18.5",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/flex.git",
-                "reference": "7a79135e1dc66b30042b4d968ecba0908f9374bc"
+                "reference": "10e438f53a972439675dc720706f0cd5c0ed94f1"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/flex/zipball/7a79135e1dc66b30042b4d968ecba0908f9374bc",
-                "reference": "7a79135e1dc66b30042b4d968ecba0908f9374bc",
+                "url": "https://api.github.com/repos/symfony/flex/zipball/10e438f53a972439675dc720706f0cd5c0ed94f1",
+                "reference": "10e438f53a972439675dc720706f0cd5c0ed94f1",
                 "shasum": ""
             },
             "require": {
@@ -1650,7 +1650,7 @@
             "description": "Composer plugin for Symfony",
             "support": {
                 "issues": "https://github.com/symfony/flex/issues",
-                "source": "https://github.com/symfony/flex/tree/v1.17.6"
+                "source": "https://github.com/symfony/flex/tree/v1.18.5"
             },
             "funding": [
                 {
@@ -1666,7 +1666,7 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2021-11-29T15:39:37+00:00"
+            "time": "2022-02-16T17:26:46+00:00"
         },
         {
             "name": "symfony/framework-bundle",

--- a/config/packages/assets.yaml
+++ b/config/packages/assets.yaml
@@ -1,3 +1,0 @@
-framework:
-    assets:
-        json_manifest_path: '%kernel.project_dir%/public/build/manifest.json'

--- a/config/packages/dev/web_profiler.yaml
+++ b/config/packages/dev/web_profiler.yaml
@@ -1,6 +1,0 @@
-web_profiler:
-    toolbar: true
-    intercept_redirects: false
-
-framework:
-    profiler: { only_exceptions: false }

--- a/config/packages/prod/webpack_encore.yaml
+++ b/config/packages/prod/webpack_encore.yaml
@@ -1,4 +1,0 @@
-#webpack_encore:
-    # Cache the entrypoints.json (rebuild Symfony's cache when entrypoints.json changes)
-    # Available in version 1.2
-    #cache: true

--- a/config/packages/test/web_profiler.yaml
+++ b/config/packages/test/web_profiler.yaml
@@ -1,6 +1,0 @@
-web_profiler:
-    toolbar: false
-    intercept_redirects: false
-
-framework:
-    profiler: { collect: false }

--- a/config/packages/test/webpack_encore.yaml
+++ b/config/packages/test/webpack_encore.yaml
@@ -1,2 +1,0 @@
-#webpack_encore:
-#    strict_mode: false

--- a/config/packages/web_profiler.yaml
+++ b/config/packages/web_profiler.yaml
@@ -1,0 +1,15 @@
+when@dev:
+    web_profiler:
+        toolbar: true
+        intercept_redirects: false
+
+    framework:
+        profiler: { only_exceptions: false }
+
+when@test:
+    web_profiler:
+        toolbar: false
+        intercept_redirects: false
+
+    framework:
+        profiler: { collect: false }

--- a/config/packages/webpack_encore.yaml
+++ b/config/packages/webpack_encore.yaml
@@ -33,3 +33,17 @@ webpack_encore:
     # Cache the entrypoints.json (rebuild Symfony's cache when entrypoints.json changes)
     # Put in config/packages/prod/webpack_encore.yaml
     # cache: true
+
+framework:
+    assets:
+        json_manifest_path: '%kernel.project_dir%/public/build/manifest.json'
+
+#when@prod:
+#    webpack_encore:
+#        # Cache the entrypoints.json (rebuild Symfony's cache when entrypoints.json changes)
+#        # Available in version 1.2
+#        cache: true
+
+#when@test:
+#    webpack_encore:
+#        strict_mode: false

--- a/config/routes/dev/web_profiler.yaml
+++ b/config/routes/dev/web_profiler.yaml
@@ -1,7 +1,0 @@
-web_profiler_wdt:
-    resource: '@WebProfilerBundle/Resources/config/routing/wdt.xml'
-    prefix: /_wdt
-
-web_profiler_profiler:
-    resource: '@WebProfilerBundle/Resources/config/routing/profiler.xml'
-    prefix: /_profiler

--- a/config/routes/web_profiler.yaml
+++ b/config/routes/web_profiler.yaml
@@ -1,0 +1,8 @@
+when@dev:
+    web_profiler_wdt:
+        resource: '@WebProfilerBundle/Resources/config/routing/wdt.xml'
+        prefix: /_wdt
+
+    web_profiler_profiler:
+        resource: '@WebProfilerBundle/Resources/config/routing/profiler.xml'
+        prefix: /_profiler

--- a/config/services.yaml
+++ b/config/services.yaml
@@ -22,7 +22,6 @@ services:
             - '../src/DependencyInjection/'
             - '../src/Entity/'
             - '../src/Kernel.php'
-            - '../src/Tests/'
 
     # add more service definitions when explicit configuration is needed
     # please note that last definitions always *replace* previous ones

--- a/symfony.lock
+++ b/symfony.lock
@@ -257,7 +257,7 @@
             "repo": "github.com/symfony/recipes",
             "branch": "master",
             "version": "5.4",
-            "ref": "bffbb8f1a849736e64006735afae730cb428b6ff"
+            "ref": "bb2178c57eee79e6be0b297aa96fc0c0def81387"
         },
         "files": [
             "config/packages/twig.yaml",

--- a/symfony.lock
+++ b/symfony.lock
@@ -291,8 +291,8 @@
         "recipe": {
             "repo": "github.com/symfony/recipes",
             "branch": "master",
-            "version": "1.9",
-            "ref": "d2d1e09675fff3fa4193aa9950a7c39934524a25"
+            "version": "1.10",
+            "ref": "2858aeed7e1d81a45365c049eb533cc8827e380b"
         },
         "files": [
             "assets/app.js",
@@ -300,9 +300,6 @@
             "assets/controllers.json",
             "assets/controllers/hello_controller.js",
             "assets/styles/app.css",
-            "config/packages/assets.yaml",
-            "config/packages/prod/webpack_encore.yaml",
-            "config/packages/test/webpack_encore.yaml",
             "config/packages/webpack_encore.yaml",
             "package.json",
             "webpack.config.js"

--- a/symfony.lock
+++ b/symfony.lock
@@ -278,13 +278,12 @@
         "recipe": {
             "repo": "github.com/symfony/recipes",
             "branch": "master",
-            "version": "3.3",
-            "ref": "6bdfa1a95f6b2e677ab985cd1af2eae35d62e0f6"
+            "version": "5.3",
+            "ref": "24bbc3d84ef2f427f82104f766014e799eefcc3e"
         },
         "files": [
-            "config/packages/dev/web_profiler.yaml",
-            "config/packages/test/web_profiler.yaml",
-            "config/routes/dev/web_profiler.yaml"
+            "config/packages/web_profiler.yaml",
+            "config/routes/web_profiler.yaml"
         ]
     },
     "symfony/webpack-encore-bundle": {

--- a/symfony.lock
+++ b/symfony.lock
@@ -131,7 +131,7 @@
             "repo": "github.com/symfony/recipes",
             "branch": "master",
             "version": "5.4",
-            "ref": "d4131812e20853626928e73d3effef44014944c0"
+            "ref": "3cd216a4d007b78d8554d44a5b1c0a446dab24fb"
         },
         "files": [
             "config/packages/cache.yaml",

--- a/symfony.lock
+++ b/symfony.lock
@@ -210,7 +210,7 @@
             "repo": "github.com/symfony/recipes",
             "branch": "master",
             "version": "5.3",
-            "ref": "44633353926a0382d7dfb0530922c5c0b30fae11"
+            "ref": "85de1d8ae45b284c3c84b668171d2615049e698f"
         },
         "files": [
             "config/packages/routing.yaml",


### PR DESCRIPTION
Update `symfony/flex` to version 1.18 with `recipe:update` command.

Updated recipes:
- symfony/framework-bundle
- symfony/routing
- symfony/twig-bundle
- symfony/web-profiler-bundle
- symfony/webpack-encore-bundle