### PR TITLE
Fix: Route priority order

### DIFF
--- a/config/routes.yaml
+++ b/config/routes.yaml
@@ -1,3 +1,7 @@
-#index:
-#    path: /
-#    controller: App\Controller\DefaultController::index
+controllers:
+    resource: ../src/Controller/
+    type: annotation
+
+kernel:
+    resource: ../src/Kernel.php
+    type: annotation

--- a/config/routes/annotations.yaml
+++ b/config/routes/annotations.yaml
@@ -1,7 +1,0 @@
-controllers:
-    resource: ../../src/Controller/
-    type: annotation
-
-kernel:
-    resource: ../../src/Kernel.php
-    type: annotation

--- a/config/routes/dev/framework.yaml
+++ b/config/routes/dev/framework.yaml
@@ -1,3 +1,0 @@
-_errors:
-    resource: '@FrameworkBundle/Resources/config/routing/errors.xml'
-    prefix: /_error

--- a/src/Controller/ArchiveController.php
+++ b/src/Controller/ArchiveController.php
@@ -19,7 +19,7 @@ class ArchiveController extends AbstractController
     /**
      * @Route(
      *     "/{path}",
-     *     name="archive_list",
+     *     name="app_archive_list",
      *     methods={"GET"},
      *     requirements={"path"=".+(\.zip|cbz)$"}
      * )
@@ -43,7 +43,7 @@ class ArchiveController extends AbstractController
     /**
      * @Route(
      *     "/{archive_item}",
-     *     name="archive_item",
+     *     name="app_archive_item",
      *     methods={"GET"},
      *     requirements={"archive_item"=".+(\.zip|cbz\/).+$"}
      * )

--- a/src/Controller/AssetsController.php
+++ b/src/Controller/AssetsController.php
@@ -15,7 +15,7 @@ use Symfony\Component\Routing\Annotation\Route;
 class AssetsController extends AbstractController
 {
     /**
-     * @Route("/build/{assets}", name="assets", methods={"GET"}, requirements={"assets"=".+"})
+     * @Route("/build/{assets}", name="app_assets", methods={"GET"}, requirements={"assets"=".+"})
      */
     public function index(ParameterBagInterface $parameterBag, MimeGuesser $guesser, string $assets): Response
     {

--- a/src/Controller/DefaultController.php
+++ b/src/Controller/DefaultController.php
@@ -18,7 +18,7 @@ class DefaultController extends AbstractController
 {
     /**
      * @Route("/", name="app_home", methods={"GET"})
-     * @Route("/{path}", name="default", methods={"GET"}, requirements={"path"="^(?!build).+"})
+     * @Route("/{path}", name="app_default", methods={"GET"}, requirements={"path"="^(?!build).+"})
      */
     public function index(DirectoryListing $listing, Request $request, NextChapterResolver $resolver, string $mangaRoot, PaginatorInterface $paginator): Response
     {

--- a/src/Controller/SearchController.php
+++ b/src/Controller/SearchController.php
@@ -14,7 +14,7 @@ use Symfony\Component\Routing\Annotation\Route;
 class SearchController extends AbstractController
 {
     /**
-     * @Route("/search", name="search", priority=10)
+     * @Route("/search", name="app_search", priority=10)
      */
     public function index(Request $request, Search $search, PaginatorInterface $paginator): Response
     {

--- a/templates/partial/_header.html.twig
+++ b/templates/partial/_header.html.twig
@@ -14,7 +14,7 @@
           d="M280.37 148.26L96 300.11V464a16 16 0 0 0 16 16l112.06-.29a16 16 0 0 0 15.92-16V368a16 16 0 0 1 16-16h64a16 16 0 0 1 16 16v95.64a16 16 0 0 0 16 16.05L464 480a16 16 0 0 0 16-16V300L295.67 148.26a12.19 12.19 0 0 0-15.3 0zM571.6 251.47L488 182.56V44.05a12 12 0 0 0-12-12h-56a12 12 0 0 0-12 12v72.61L318.47 43a48 48 0 0 0-61 0L4.34 251.47a12 12 0 0 0-1.6 16.9l25.5 31A12 12 0 0 0 45.15 301l235.22-193.74a12.19 12.19 0 0 1 15.3 0L530.9 301a12 12 0 0 0 16.9-1.6l25.5-31a12 12 0 0 0-1.7-16.93z"></path>
       </svg>
     </a>
-    <form action="{{ path('search') }}" class="flex-grow max-w-md">
+    <form action="{{ path('app_search') }}" class="flex-grow max-w-md">
       <input type="text"
         name="q"
         class="w-full px-1 h-8 bg-gray-900 text-white focus:bg-white text-sm focus:text-gray-900 border border-gray-700 rounded"


### PR DESCRIPTION
Make sure application route is loaded in last order. This will prevent application route to intercept web profiler.