### PR TITLE
Refactor: Introduce custom twig filter to fix prettier unsupported filter syntax

### DIFF
--- a/src/Twig/AppExtension.php
+++ b/src/Twig/AppExtension.php
@@ -34,6 +34,8 @@ class AppExtension extends AbstractExtension
     {
         return [
             new TwigFilter('is_image', [$this, 'isImage']),
+            new TwigFilter('filter_image', [$this, 'filterImage']),
+            new TwigFilter('filter_cover', [$this, 'filterCover']),
         ];
     }
 
@@ -44,6 +46,24 @@ class AppExtension extends AbstractExtension
             new TwigFunction('is_image', [$this, 'isImage']),
             new TwigFunction('render_breadcrumbs', [$this, 'renderBreadcrumbs'], ['is_safe' => ['html'], 'needs_environment' => true]),
         ];
+    }
+
+    public function filterImage(\Traversable $items): iterable
+    {
+        $items = iterator_to_array($items);
+
+        return array_filter($items, function ($item) {
+            return $this->isImage($item['uri']);
+        });
+    }
+
+    public function filterCover(\Traversable $items, bool $withCover = true): iterable
+    {
+        $items = iterator_to_array($items);
+
+        return array_filter($items, function ($item) use ($withCover) {
+            return $withCover ? $item['cover'] : !$item['cover'];
+        });
     }
 
     public function isImage(string $value): bool

--- a/templates/entry_list.html.twig
+++ b/templates/entry_list.html.twig
@@ -4,23 +4,23 @@
   {% include 'partial/_header.html.twig' %}
   <main class="pt-12 text-gray-100">
     <div class="container mx-auto font-thin">
-      {{render_breadcrumbs()}}
+      {{ render_breadcrumbs() }}
       <div class="mt-2 px-2" {{ stimulus_target('app', 'entryContainer') }}>
         <div class="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-2">
-          {% for item in pagination|filter(item => not item.cover) %}
+          {% for item in pagination|filter_cover(false) %}
             <div class="border-b border-gray-600">
               {{ block('no_cover') }}
             </div>
           {% endfor %}
         </div>
         <div class="mt-2 grid grid-cols-1 md:grid-cols-4 lg:grid-cols-5 xl:grid-cols-6 gap-2">
-          {% for item in pagination|filter(item => item.cover) %}
+          {% for item in pagination|filter_cover %}
             {{ block('has_cover') }}
           {% endfor %}
         </div>
       </div>
       <div class="hidden mt-2 w-full mx-auto overflow-x-hidden" {{ stimulus_target('app', 'imageContainer') }}>
-        {% for item in pagination|filter(item => item.uri|is_image) %}
+        {% for item in pagination|filter_image %}
           <img class="md:col-span-3 min-h-screen mx-auto lozad"
             loading="lazy"
             data-src="{{ item.uri }}"


### PR DESCRIPTION
Prettier doesn't support twig `filter` filter syntax.

```twig
{% set numbers = [8, 9, 10, 11, 12] %}
{{ numbers|filter(number => number > 10) }}
```