### PR TITLE
Use npm ci to install dependencies

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -47,7 +47,7 @@ jobs:
                 run: |
                     composer install --no-progress --prefer-dist --optimize-autoloader
             -   name: Install npm dependencies
-                run: npm install
+                run: npm ci
             -   name: Lint code style
                 run: |
                     bin/console lint:twig

--- a/bin/build
+++ b/bin/build
@@ -9,7 +9,7 @@ rm -fr build
 mkdir -p ${BUILD_DIR}
 
 # Install frontend dependencies
-npm install
+npm ci
 
 # Build frontend artifact
 npm run build
@@ -35,3 +35,7 @@ cd ${BUILD_DIR} \
 
 # Remove php_cs cache
 find build -type f -name "*.cache" -exec rm {} \;
+
+# Overwrite latest build
+rm -fr build/manga-server-latest
+cp -r ${BUILD_DIR} build/manga-server-latest


### PR DESCRIPTION
Avoid modifying package-lock.json file when installing npm packages.