### PR TITLE
Remove line-clamp plugin from tailwindcss

### DIFF
--- a/package.json
+++ b/package.json
@@ -5,7 +5,6 @@
         "@hotwired/stimulus": "^3.0.0",
         "@symfony/stimulus-bridge": "^3.2.0",
         "@symfony/webpack-encore": "^4.0.0",
-        "@tailwindcss/line-clamp": "^0.3.1",
         "autoprefixer": "^10.3.3",
         "core-js": "^3.23.0",
         "postcss-loader": "^7.0.0",

--- a/tailwind.config.js
+++ b/tailwind.config.js
@@ -6,5 +6,5 @@ module.exports = {
   variants: {
     extend: {},
   },
-  plugins: [require('@tailwindcss/line-clamp')],
+  plugins: [],
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -1091,11 +1091,6 @@
     webpack-dev-server "^4.8.0"
     yargs-parser "^21.0.0"
 
-"@tailwindcss/line-clamp@^0.3.1":
-  version "0.3.1"
-  resolved "https://registry.yarnpkg.com/@tailwindcss/line-clamp/-/line-clamp-0.3.1.tgz#4d8441b509b87ece84e94f28a4aa9998413ab849"
-  integrity sha512-pNr0T8LAc3TUx/gxCfQZRe9NB2dPEo/cedPHzUGIPxqDMhgjwNm6jYxww4W5l0zAsAddxr+XfZcqttGiFDgrGg==
-
 "@trysound/sax@0.2.0":
   version "0.2.0"
   resolved "https://registry.yarnpkg.com/@trysound/sax/-/sax-0.2.0.tgz#cccaab758af56761eb7bf37af6f03f326dd798ad"


### PR DESCRIPTION
It has been included on tailwindcss since version 3.3