### PR TITLE
Optimize building search index

### DIFF
--- a/CHANGELOG.txt
+++ b/CHANGELOG.txt
@@ -2,6 +2,9 @@ Manga Server
 https://github.com/zackad/manga-server
 
 next (unreleased)
+Bugfixes:
+- Optimize building search index to reduce memory usage
+
 Internals:
 - Add GitHub action to build release artifact
 - Add prettier with twig and tailwindcss plugin as dev dependencies

--- a/src/Service/Search.php
+++ b/src/Service/Search.php
@@ -5,7 +5,6 @@ declare(strict_types=1);
 namespace App\Service;
 
 use Symfony\Component\Finder\Finder;
-use Symfony\Component\Finder\SplFileInfo;
 use Symfony\Component\Routing\Generator\UrlGeneratorInterface;
 use Symfony\Contracts\Cache\CacheInterface;
 use Symfony\Contracts\Cache\ItemInterface;
@@ -87,20 +86,21 @@ class Search
                 ->followLinks()
                 ->in($this->mangaRoot)
                 ->exclude($excludedFinderPath)
-                ->name($patterns)
-                ->sortByName(true);
+                ->name($patterns);
 
-            $list = iterator_to_array($this->finder);
-            $mappedArray = array_map(
-                function (SplFileInfo $item) {
-                    return [
-                        'basename' => $item->getBasename(),
-                        'realpath' => $item->getRealPath(),
-                        'relative_path' => sprintf('/%s/%s', $item->getRelativePath(), $item->getBasename()),
-                    ];
-                }, $list);
+            $indexData = [];
+            foreach ($this->finder as $item) {
+                $indexData[] = [
+                    'basename' => $item->getBasename(),
+                    'realpath' => $item->getRealPath(),
+                    'relative_path' => sprintf('/%s/%s', $item->getRelativePath(), $item->getBasename()),
+                ];
+            }
+            usort($indexData, function ($a, $b) {
+                return strnatcmp($a['basename'], $b['basename']);
+            });
 
-            return array_values($mappedArray);
+            return array_values($indexData);
         });
     }
 }


### PR DESCRIPTION
Close #126 

BREAKING CHANGE: natural sort on symfony finder use realpath as comparator, while our implementation use basename.

Disable sorting by name on finder to prevent memory leak. Use iterator to push data into array instead of converting iterator to array directly.