### PR TITLE
Docker support for deployment

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,8 @@
+.devenv
+.direnv
+build
+dist
+node_modules
+tools
+var
+vendor

--- a/CHANGELOG.txt
+++ b/CHANGELOG.txt
@@ -3,6 +3,9 @@ https://github.com/zackad/manga-server
 
 next (unreleased)
 
+Features:
+- Add support to run application as docker container
+
 Internals:
 - Update nix packages
 - Configure pre-commit hooks to use devtools managed by package manager

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,31 @@
+FROM composer:2 AS builder
+
+ENV COMPOSER_IGNORE_PLATFORM_REQS=1
+WORKDIR /app
+COPY . /app
+RUN apk add --no-cache nodejs yarn
+RUN bin/build
+
+FROM dunglas/frankenphp:1-php8.3-alpine
+
+# Configure and install additional php extension
+# Option 1: gd extention with "jpeg png webp" support
+RUN apk add --no-cache libjpeg-turbo-dev libpng-dev libwebp-dev libzip-dev \
+    && docker-php-ext-configure gd --with-jpeg --with-webp \
+    && docker-php-ext-install gd zip
+
+# Option 2: gd extention with "avif freetype jpeg png xpm webp" support
+#RUN apk add --no-cache freetype-dev libavif-dev libjpeg-turbo-dev libpng-dev libwebp-dev libxpm-dev libzip-dev \
+#    && docker-php-ext-configure gd --with-avif --with-jpeg --with-xpm --with-webp --with-freetype \
+#    && docker-php-ext-install gd zip
+
+COPY --from=builder /app/build/manga-server /app
+RUN mkdir -p /data \
+    && chown -R 1000:1000 /app /data
+
+USER 1000:1000
+WORKDIR /app
+
+LABEL org.opencontainers.image.source=https://github.com/zackad/manga-server
+
+ENTRYPOINT ["frankenphp", "php-server", "--root", "public", "--listen", ":8000"]

--- a/README.md
+++ b/README.md
@@ -24,6 +24,22 @@ Web application to serve manga collection from your computer over the network.
 
 ## How to run
 
+### Using Docker
+> [!NOTE]
+> To prevent accidental data lost, make sure to mount your media volume as readonly.
+
+> [!IMPORTANT]
+> By default, memory limit is 128MB and might not be enough to generage cover thumbnail (see #199).
+> You can increase memory limit by setting `APP_MEMORY_LIMIT` env variable to the desired value.
+```shell
+docker run -d --publish 8000:8000 \
+    --env APP_MEMORY_LIMIT=1G \
+    --env MANGA_ROOT_DIRECTORY=/media \
+    --volume /path/to/your/media:/media:ro \
+    ghcr.io/zackad/manga-server:latest
+```
+
+### Manual
 - Download zip file from the [latest release page](https://github.com/zackad/manga-server/releases/latest)
 - Extract
 - Open `.env` file and change `MANGA_ROOT_DIRECTORY` value to your manga collection folder. Alternatively you can copy `.env` file into `.env.local` to prevent your value to be overwritten when you update the app later.


### PR DESCRIPTION
Close GH-156

__TODO__:
- [x] add deployment guide
- [x] push docker image into `ghcr.io` (using `next` tag, as I deem it not ready)
- [x] add changelog