### PR TITLE
Use raw url encoding/decoding to handle special character

### DIFF
--- a/CHANGELOG.txt
+++ b/CHANGELOG.txt
@@ -2,6 +2,8 @@ Manga Server
 https://github.com/zackad/manga-server
 
 next (unreleased)
+Bugfixes:
+- Use raw url encoding/decoding to handle special character
 
 ---
 v0.19.0 (2024-01-14)

--- a/src/Controller/ArchiveController.php
+++ b/src/Controller/ArchiveController.php
@@ -61,6 +61,7 @@ class ArchiveController extends AbstractController
     public function archiveItem(Request $request, MimeGuesser $guesser): Response
     {
         $path = $request->attributes->get('archive_item');
+        $path = rawurldecode($path);
         $target = sprintf('%s/%s', $this->mangaRoot, $path);
         $archivePath = (string) preg_replace('/(?<=\.cbz|\.epub|\.zip).*$/i', '', $target);
         $archivePath = realpath(rawurldecode($archivePath));

--- a/src/Controller/CoverController.php
+++ b/src/Controller/CoverController.php
@@ -27,6 +27,7 @@ class CoverController extends AbstractController
     public function thumbnail(string $mangaRoot, Request $request, ComicBook $comicBook): Response
     {
         $filename = (string) $request->query->get('filename');
+        $filename = rawurldecode($filename);
         $size = $request->query->getInt('size', 512);
         $target = $mangaRoot.'/'.$filename;
         $cacheKey = sprintf('cover-thumbnail-%s-%s', $size, md5($filename));

--- a/src/Service/DirectoryListing.php
+++ b/src/Service/DirectoryListing.php
@@ -38,7 +38,7 @@ class DirectoryListing
     {
         /** @var string $entry */
         foreach ($entries as $entry) {
-            $requestUri = trim($uriPrefix.'/'.$entry, '/');
+            $requestUri = rawurlencode(trim($uriPrefix.'/'.$entry, '/'));
             $pathname = $target.'/'.$entry;
             $coverUrl = 'archive' !== $this->getType($pathname) ? false : $this->urlGenerator->generate('app_cover_thumbnail', ['filename' => $requestUri]);
 

--- a/src/Service/Search.php
+++ b/src/Service/Search.php
@@ -44,7 +44,7 @@ class Search
     {
         /** @var array $file */
         foreach ($list as $file) {
-            $filename = trim((string) $file['relative_path'], '/');
+            $filename = rawurlencode(trim((string) $file['relative_path'], '/'));
             $uri = $this->urlGenerator->generate('app_archive_list', ['path' => $filename]);
             $coverUrl = $this->urlGenerator->generate('app_cover_thumbnail', ['filename' => $filename]);
             yield [


### PR DESCRIPTION
Some filename might contains special character that has meaning in the context of url parsing such as `#;?`. This character need to be encode/decode to prevent webserver or application interpreting it as special character instead of part of filename.

Close #198.