### PR TITLE
Log error and deprecation into file on prod environment

### DIFF
--- a/CHANGELOG.txt
+++ b/CHANGELOG.txt
@@ -3,6 +3,9 @@ https://github.com/zackad/manga-server
 
 next (unreleased)
 
+Internal:
+- Log error and deprecation into file on prod environment
+
 ---
 v0.20.0 (2024-01-21)
 Features:

--- a/config/packages/monolog.yaml
+++ b/config/packages/monolog.yaml
@@ -48,7 +48,7 @@ when@prod:
                 buffer_size: 50 # How many messages should be saved? Prevent memory leaks
             nested:
                 type: stream
-                path: php://stderr
+                path: "%kernel.logs_dir%/%kernel.environment%.log"
                 level: debug
                 formatter: monolog.formatter.json
             console:
@@ -58,4 +58,4 @@ when@prod:
             deprecation:
                 type: stream
                 channels: [deprecation]
-                path: php://stderr
+                path: "%kernel.logs_dir%/deprecation-%kernel.environment%.log"


### PR DESCRIPTION
Make it easier to debug error on production by tracing error log on actual file compared to stderr that not properly forwarded by docker container runtime.