### PR TITLE
Configure php memory limit via env variable

### DIFF
--- a/.env
+++ b/.env
@@ -27,4 +27,11 @@ MAXIMUM_SEARCH_DEPTH=3
 # Use space separated value and avoid using special character for directory name
 # example: SEARCH_INDEX_EXCLUDED='Directory-1 Directory-2 Directory-3/Subdirectory'
 SEARCH_INDEX_EXCLUDED=''
+
+# OPTIONAL
+# uncomment and set memory limit to allow cover thumbnail generation
+# for large image. When this application is run on docker container
+# there's memory leak issue.
+#APP_MEMORY_LIMIT=128M
+
 ###< Custom environment ###

--- a/CHANGELOG.txt
+++ b/CHANGELOG.txt
@@ -2,6 +2,8 @@ Manga Server
 https://github.com/zackad/manga-server
 
 next (unreleased)
+Features:
+- Allow to set php memory limit for generating cover thumbnail via env variable
 
 ---
 v0.21.0 (2024-01-31)

--- a/config/services.yaml
+++ b/config/services.yaml
@@ -4,6 +4,7 @@
 # Put parameters here that don't need to change on each machine where the app is deployed
 # https://symfony.com/doc/current/best_practices.html#use-parameters-for-application-configuration
 parameters:
+    default_memory_limit: '128M'
 
 services:
     # default configuration for services in *this* file
@@ -14,6 +15,7 @@ services:
             $mangaRoot: '%env(resolve:MANGA_ROOT_DIRECTORY)%'
             $searchIndexExcluded: '%env(SEARCH_INDEX_EXCLUDED)%'
             $projectRoot: '%kernel.project_dir%'
+            $memoryLimit: '%env(default:default_memory_limit:APP_MEMORY_LIMIT)%'
 
     # makes classes in src/ available to be used as services
     # this creates a service per class whose id is the fully-qualified class name

--- a/src/Controller/CoverController.php
+++ b/src/Controller/CoverController.php
@@ -19,7 +19,7 @@ class CoverController extends AbstractController
 {
     private const CACHE_EXPIRES_AFTER = '+1 months';
 
-    public function __construct(private readonly TagAwareCacheInterface $cache)
+    public function __construct(private readonly TagAwareCacheInterface $cache, private readonly string $memoryLimit)
     {
     }
 
@@ -46,7 +46,7 @@ class CoverController extends AbstractController
             $stream = $zipArchive->getStream($entryName);
 
             // Temporary fix to handle memory exhaustion when processing large image
-            ini_set('memory_limit', '256M');
+            ini_set('memory_limit', $this->memoryLimit);
 
             $imagine = new Imagine();
             $size = new Box($size, $size);


### PR DESCRIPTION
Allow user to define their own memory limit for php process when generating cover thumbnail. When running under docker container, there is an issue with memory consumtion that significantly higher compared to non docker runtime (nix based packages).

I have no idea how to debug and fix the problem. The hardcoded memory limit still not enough for my use case. With this feature, I can increase the limit without modifying application code and redeploy the app. Just edit `APP_MEMORY_LIMIT` env variable and clear the cache.