### PR TITLE
Chore: Use frankenphp as runtime and dev server

### DIFF
--- a/CHANGELOG.txt
+++ b/CHANGELOG.txt
@@ -5,6 +5,7 @@ next (unreleased)
 
 Internals:
 - DX: integrate devenv into nix flakes
+- DX: use frankenphp as runtime, replacing symfony-cli as dev server
 
 ---
 v0.23.0 (2024-02-24)

--- a/devenv.nix
+++ b/devenv.nix
@@ -6,10 +6,10 @@
 
   # https://devenv.sh/packages/
   packages = [
-    pkgs.php83Extensions.xdebug
-    pkgs.php83Packages.phive
+    pkgs.frankenphp
+    pkgs.php82Extensions.xdebug
+    pkgs.php82Packages.phive
     pkgs.nodejs-slim_18
-    pkgs.symfony-cli
     pkgs.yarn
     pkgs.zip
   ];
@@ -25,7 +25,7 @@
   # languages.nix.enable = true;
   languages.php = {
     enable = true;
-    package = pkgs.php83.buildEnv {
+    package = pkgs.php82.buildEnv {
       # List of php extension required
       extensions = { all, enabled }: with all; enabled ++ [ pcov ];
     };
@@ -40,7 +40,7 @@
 
   # https://devenv.sh/processes/
   processes.asset.exec = "yarn run dev";
-  processes.web.exec = "symfony server:start --no-tls";
+  processes.web.exec = "frankenphp php-server --root public --listen :8000";
 
   # See full reference at https://devenv.sh/reference/options/
 }


### PR DESCRIPTION
Close #171

FrankenPHP offer nice feature to run php application without setting up separate process to handle web server and php runtime. Unfortunately, we have to dowdgrade php version to 8.2 since it is the default version providen by nixpkgs currently. symfony-cli has been removed since it is no longer being used.