### PR TITLE
Chore: Replace process manager for devenv `honcho` -> `overmind`

### DIFF
--- a/CHANGELOG.txt
+++ b/CHANGELOG.txt
@@ -6,6 +6,7 @@ next (unreleased)
 Internals:
 - DX: integrate devenv into nix flakes
 - DX: use frankenphp as runtime, replacing symfony-cli as dev server
+- Replace process manager implementation for devenv `honcho` -> `overmind`
 
 ---
 v0.23.0 (2024-02-24)

--- a/devenv.nix
+++ b/devenv.nix
@@ -3,6 +3,7 @@
 {
   # https://devenv.sh/basics/
   env.GREET = "devenv";
+  env.OVERMIND_SKIP_ENV = true;
 
   # https://devenv.sh/packages/
   packages = [
@@ -35,8 +36,7 @@
   # pre-commit.hooks.shellcheck.enable = true;
 
   # https://devenv.sh/reference/options/#processimplementation
-  # Select `honcho` as process manager
-  process.implementation = "honcho";
+  process.implementation = "overmind";
 
   # https://devenv.sh/processes/
   processes.asset.exec = "yarn run dev";


### PR DESCRIPTION
Close #219

Overmind has feature to autorestart process which is nice to have. Will be usefull for managing messenger worker and scheduler in the future.