### PR TITLE
Chore: Update pre-commit hooks to use devtool from package manager

### DIFF
--- a/CHANGELOG.txt
+++ b/CHANGELOG.txt
@@ -5,6 +5,8 @@ next (unreleased)
 
 Internals:
 - Update nix packages
+- Configure pre-commit hooks to use devtools managed by package manager
+  (composer, yarn)
 
 ---
 v0.25.0 (2024-05-25)

--- a/devenv.nix
+++ b/devenv.nix
@@ -33,9 +33,37 @@
   };
 
   # https://devenv.sh/pre-commit-hooks/
-  pre-commit.hooks.php-cs-fixer.enable = true;
-  pre-commit.hooks.phpstan.enable = true;
-  pre-commit.hooks.prettier.enable = true;
+  pre-commit.hooks = {
+    nixfmt-rfc-style.enable = true;
+    prettier = {
+      enable = true;
+      package = null; # use version managed by yarn
+      entry = "node_modules/.bin/prettier --ignore-unknown --list-different --write";
+    };
+    php-cs-fixer = {
+      enable = true;
+      package = null; # use version managed by phive
+      entry = "tools/php-cs-fixer --config=.php-cs-fixer.dist.php fix";
+    };
+    phpstan = {
+      enable = true;
+      package = null; # use version managed by composer
+      entry = "vendor/bin/phpstan --memory-limit=-1 analyze";
+      excludes = [
+        "^config/secrets/.+"
+        "^tests/.+"
+        ".php-cs-fixer.dist.php"
+        "deploy.dist.php"
+      ];
+    };
+
+    # Custom hooks not provided by devenv
+    twig-lint = {
+      enable = true;
+      entry = "bin/console lint:twig";
+      types = [ "twig" ];
+    };
+  };
 
   # https://devenv.sh/reference/options/#processimplementation
   process.implementation = "overmind";


### PR DESCRIPTION
Avoid inconsistency when using devtools to run pre-commit hooks by leveraging tools managed by package manager such as composer, phive and yarn. This will make it easier to check which version that being used since it will be availabel on package manager metadata (lockfile).