### PR TITLE
Refactor: Remove incorrect metadata from docker image

### DIFF
--- a/CHANGELOG.txt
+++ b/CHANGELOG.txt
@@ -16,6 +16,7 @@ Internals:
 - Enable opcache extension on docker image
 - Optimize memory usage when generating cover thumbnail by using imagick php extension as Imagine driver
 - Update prettier plugin for twig
+- Rewrite _Dockerfile_ to remove incorrect image metadata (EXPOSE, HEALTHCHECK)
 
 ---
 v0.25.0 (2024-05-25)

--- a/Dockerfile
+++ b/Dockerfile
@@ -6,17 +6,26 @@ COPY . /app
 RUN apk add --no-cache nodejs yarn
 RUN bin/build
 
-FROM dunglas/frankenphp:1-php8.3-alpine
+FROM dunglas/frankenphp:1-php8.3-alpine AS runtime
 
 COPY --from=mlocati/php-extension-installer /usr/bin/install-php-extensions /usr/local/bin/
+
+RUN install-php-extensions imagick opcache zip
+
+# Rebuild image to remove incorrect information such as EXPOSE, HEALTHCHECK etc.
+# https://stackoverflow.com/a/72024605
+FROM scratch
+
+COPY --from=runtime / /
 COPY --from=builder /app/build/manga-server /app
 
 RUN mkdir -p /data \
-    && chown -R 1000:1000 /app /data \
-    && install-php-extensions imagick opcache zip
+    && chown -R 1000:1000 /app /data
 
 USER 1000:1000
 WORKDIR /app
+
+EXPOSE 8000
 
 LABEL org.opencontainers.image.source=https://github.com/zackad/manga-server
 


### PR DESCRIPTION
Extending existing frankenphp image will inherit their incorect metadata such as EXPOSE, HEALTHCHECK. By creating image from scratch, it will remove those data.

Ref: https://stackoverflow.com/a/72024605