### PR TITLE
Chore: Bump mimimum version of php to 8.2

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -13,7 +13,7 @@ jobs:
         runs-on: ubuntu-latest
         strategy:
             matrix:
-                php-versions: ['8.1', '8.2', '8.3']
+                php-versions: ['8.2', '8.3']
             fail-fast: false
         steps:
             -   name: Checkout

--- a/CHANGELOG.txt
+++ b/CHANGELOG.txt
@@ -3,6 +3,9 @@ https://github.com/zackad/manga-server
 
 next (unreleased)
 
+Internals:
+- Bump minimum php version to 8.2 to prepare for symfony 7.x
+
 ---
 v0.27.0 (2025-03-28)
 

--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ Web application to serve manga collection from your computer over the network.
 ## Requirements
 
 **Runtime**
-- PHP version 8.1 or later with following extension enabled:
+- PHP version 8.2 or later with following extension enabled:
   - imagick
   - zip
 

--- a/composer.json
+++ b/composer.json
@@ -1,6 +1,6 @@
 {
     "require": {
-        "php": ">=8.1",
+        "php": ">=8.2",
         "ext-ctype": "*",
         "ext-iconv": "*",
         "ext-imagick": "*",

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "0bfbaeae48af3acf61b5738e3797623e",
+    "content-hash": "559f4ef250a8e643dcfce1e050fa6da6",
     "packages": [
         {
             "name": "imagine/imagine",
@@ -6480,7 +6480,7 @@
     "prefer-stable": false,
     "prefer-lowest": false,
     "platform": {
-        "php": ">=8.1",
+        "php": ">=8.2",
         "ext-ctype": "*",
         "ext-iconv": "*",
         "ext-imagick": "*",


### PR DESCRIPTION
Symfony 7.x require php version 8.2 or later. Altought symfony 6.4 will receive bug fix until november 2026 and security fix until november 2027, it won't receive new feature.

This change is preparation for upgrading symfony framework to version 7.x.