### PR TITLE
Chore: Remove APP_SECRET env variable

### DIFF
--- a/.env
+++ b/.env
@@ -16,7 +16,6 @@
 
 ###> symfony/framework-bundle ###
 APP_ENV=dev
-APP_SECRET=21468ebd15e55d08deb9b753c6ba991e
 ###< symfony/framework-bundle ###
 
 ###> Custom environment ###

--- a/CHANGELOG.txt
+++ b/CHANGELOG.txt
@@ -7,6 +7,7 @@ Internals:
 - Bump minimum php version to 8.2 to prepare for symfony 7.x
 - Update php-cs-fixer to latest version (3.75.0)
 - Upgrade symfony framework to version 7.2
+- Remove APP_SECRET environment variable, it becomes optional since symfony version 7.2
 
 ---
 v0.27.0 (2025-03-28)

--- a/bin/build
+++ b/bin/build
@@ -19,7 +19,6 @@ cp -r bin config public src templates composer.json composer.lock ${BUILD_DIR}
 
 # Define environment variable
 echo "APP_ENV=prod" > ${BUILD_DIR}/.env
-echo "APP_SECRET=$(openssl rand -hex 20)" >> ${BUILD_DIR}/.env
 echo "APP_MEDIA_DIRECTORY=/media" >> ${BUILD_DIR}/.env
 echo "MAXIMUM_SEARCH_DEPTH=3" >> ${BUILD_DIR}/.env
 


### PR DESCRIPTION
It becomes optional since symfony 7.2.

Ref: https://symfony.com/blog/new-in-symfony-7-2-optional-secret