### PR TITLE
Refactor: Remove try catch when opening zip file

### DIFF
--- a/CHANGELOG.txt
+++ b/CHANGELOG.txt
@@ -3,6 +3,9 @@ https://github.com/zackad/manga-server
 
 next (unreleased)
 
+Bugfix:
+- Simplify opening zip archive check without try...catch statement
+
 Internals:
 - Bump minimum php version to 8.2 to prepare for symfony 7.x
 - Update php-cs-fixer to latest version (3.75.0)

--- a/src/Service/DirectoryListing.php
+++ b/src/Service/DirectoryListing.php
@@ -68,12 +68,11 @@ class DirectoryListing
             return 'directory';
         }
 
-        try {
-            $isArchive = $this->za->open($pathname);
-        } catch (\Exception) {
+        if (!is_readable($pathname)) {
             return 'file';
         }
 
+        $isArchive = $this->za->open($pathname);
         if (true === $isArchive) {
             return 'archive';
         }


### PR DESCRIPTION
Related GH-271

~~IIRC, ZipArchive::open will throw exception when failed to open zip file on php 7.x. This behaviour has changed, but I can't find reference on php.net documentation.~~