### PR TITLE
Bugfix: Impose actual memory limit constraint

### DIFF
--- a/.env
+++ b/.env
@@ -31,7 +31,7 @@ SEARCH_INDEX_EXCLUDED=''
 # uncomment and set memory limit to allow cover thumbnail generation
 # for large image. When this application is run on docker container
 # there's memory leak issue.
-#APP_MEMORY_LIMIT=128M
+APP_MEMORY_LIMIT=128M
 
 ###< Custom environment ###
 

--- a/CHANGELOG.txt
+++ b/CHANGELOG.txt
@@ -3,6 +3,9 @@ https://github.com/zackad/manga-server
 
 next (unreleased)
 
+Bugfix:
+- Impose actual memory limit constraint
+
 Internals:
 - Upgrade nodejs to version 22
 

--- a/config/services.yaml
+++ b/config/services.yaml
@@ -4,7 +4,6 @@
 # Put parameters here that don't need to change on each machine where the app is deployed
 # https://symfony.com/doc/current/best_practices.html#use-parameters-for-application-configuration
 parameters:
-    default_memory_limit: '128M'
 
 services:
     # default configuration for services in *this* file
@@ -15,7 +14,6 @@ services:
             $mangaRoot: '%env(resolve:APP_MEDIA_DIRECTORY)%'
             $searchIndexExcluded: '%env(SEARCH_INDEX_EXCLUDED)%'
             $projectRoot: '%kernel.project_dir%'
-            $memoryLimit: '%env(default:default_memory_limit:APP_MEMORY_LIMIT)%'
 
     # makes classes in src/ available to be used as services
     # this creates a service per class whose id is the fully-qualified class name

--- a/src/Controller/CoverController.php
+++ b/src/Controller/CoverController.php
@@ -19,7 +19,7 @@ class CoverController extends AbstractController
 {
     private const CACHE_EXPIRES_AFTER = '+1 months';
 
-    public function __construct(private readonly TagAwareCacheInterface $cache, private readonly string $memoryLimit)
+    public function __construct(private readonly TagAwareCacheInterface $cache)
     {
     }
 
@@ -44,9 +44,6 @@ class CoverController extends AbstractController
             $zipArchive->open($target);
             /** @var resource $stream */
             $stream = $zipArchive->getStream($entryName);
-
-            // Temporary fix to handle memory exhaustion when processing large image
-            ini_set('memory_limit', $this->memoryLimit);
 
             $imagine = new Imagine();
             $size = new Box($size, $size);

--- a/src/EventSubscriber/ConsoleCommandSubscriber.php
+++ b/src/EventSubscriber/ConsoleCommandSubscriber.php
@@ -14,6 +14,8 @@ class ConsoleCommandSubscriber implements EventSubscriberInterface
     public function __construct(
         #[Autowire('%kernel.project_dir%')]
         private readonly string $projectDir,
+        #[Autowire('%env(APP_MEMORY_LIMIT)%')]
+        private readonly string $memoryLimit,
     ) {
     }
 
@@ -29,10 +31,18 @@ class ConsoleCommandSubscriber implements EventSubscriberInterface
         }
     }
 
+    public function setMemoryLimit(): void
+    {
+        ini_set('memory_limit', $this->memoryLimit);
+    }
+
     public static function getSubscribedEvents(): array
     {
         return [
-            'console.command' => 'onConsoleCommand',
+            ConsoleCommandEvent::class => [
+                ['onConsoleCommand'],
+                ['setMemoryLimit'],
+            ],
         ];
     }
 }

--- a/src/EventSubscriber/KernelSubscriber.php
+++ b/src/EventSubscriber/KernelSubscriber.php
@@ -1,0 +1,30 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\EventSubscriber;
+
+use Symfony\Component\DependencyInjection\Attribute\Autowire;
+use Symfony\Component\EventDispatcher\EventSubscriberInterface;
+use Symfony\Component\HttpKernel\Event\RequestEvent;
+
+class KernelSubscriber implements EventSubscriberInterface
+{
+    public function __construct(
+        #[Autowire('%env(APP_MEMORY_LIMIT)%')]
+        private readonly string $memoryLimit,
+    ) {
+    }
+
+    public function onRequestEvent(RequestEvent $event): void
+    {
+        ini_set('memory_limit', $this->memoryLimit);
+    }
+
+    public static function getSubscribedEvents(): array
+    {
+        return [
+            RequestEvent::class => 'onRequestEvent',
+        ];
+    }
+}

--- a/tests/EventSubscriber/ConsoleCommandSubscriberTest.php
+++ b/tests/EventSubscriber/ConsoleCommandSubscriberTest.php
@@ -31,7 +31,7 @@ class ConsoleCommandSubscriberTest extends TestCase
         $input = $this->createMock(InputInterface::class);
         $output = $this->createMock(OutputInterface::class);
         $event = new ConsoleCommandEvent($command, $input, $output);
-        $subscriber = new ConsoleCommandSubscriber($this->rootDataDirectory);
+        $subscriber = new ConsoleCommandSubscriber($this->rootDataDirectory, '128M');
 
         // Check if initial state is not exists
         self::assertDirectoryDoesNotExist($this->rootDataDirectory);
@@ -40,17 +40,26 @@ class ConsoleCommandSubscriberTest extends TestCase
         self::assertDirectoryExists($this->rootDataDirectory.'/var/data');
     }
 
-    public function testDataDirectoryIsNotCreatedWhenOnOtherComman(): void
+    public function testDataDirectoryIsNotCreatedWhenOnOtherCommand(): void
     {
         $command = new Command('about');
         $input = $this->createMock(InputInterface::class);
         $output = $this->createMock(OutputInterface::class);
         $event = new ConsoleCommandEvent($command, $input, $output);
-        $subscriber = new ConsoleCommandSubscriber($this->rootDataDirectory);
+        $subscriber = new ConsoleCommandSubscriber($this->rootDataDirectory, '128M');
 
         $subscriber->onConsoleCommand($event);
 
         self::assertDirectoryDoesNotExist($this->rootDataDirectory.'/var/data');
+    }
+
+    public function testMemoryLimitBeingImposed(): void
+    {
+        $subscriber = new ConsoleCommandSubscriber($this->rootDataDirectory, '1G');
+
+        $subscriber->setMemoryLimit();
+
+        self::assertEquals('1G', ini_get('memory_limit'));
     }
 
     public function testMakeSureIsCovered(): void

--- a/tests/EventSubscriber/KernelSubscriberTest.php
+++ b/tests/EventSubscriber/KernelSubscriberTest.php
@@ -1,0 +1,33 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Tests\EventSubscriber;
+
+use App\EventSubscriber\KernelSubscriber;
+use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\TestCase;
+use Symfony\Component\HttpFoundation\Request;
+use Symfony\Component\HttpKernel\Event\RequestEvent;
+use Symfony\Component\HttpKernel\HttpKernelInterface;
+
+#[CoversClass(KernelSubscriber::class)]
+class KernelSubscriberTest extends TestCase
+{
+    public function testMemoryLimitBeingImposed(): void
+    {
+        $subscriber = new KernelSubscriber('512M');
+        $kernel = $this->createMock(HttpKernelInterface::class);
+        $request = $this->createMock(Request::class);
+        $event = new RequestEvent($kernel, $request, null);
+
+        $subscriber->onRequestEvent($event);
+
+        self::assertEquals('512M', ini_get('memory_limit'));
+    }
+
+    public function testMakeSureIsCovered(): void
+    {
+        self::assertIsArray(KernelSubscriber::getSubscribedEvents());
+    }
+}


### PR DESCRIPTION
Environment variable APP_MEMORY_LIMIT now defined by default and set to php memory limit 128M. Memory limit has been set globally by event subscriber to make sure that this constraint is being respected everywhere.