### PR TITLE
Performace: Add count limit for scheduler

### DIFF
--- a/s6/etc/s6-overlay/s6-rc.d/scheduler/run
+++ b/s6/etc/s6-overlay/s6-rc.d/scheduler/run
@@ -1,2 +1,2 @@
 #!/command/with-contenv sh
-php /app/bin/console messenger:consume scheduler_default --time-limit=86400
+php /app/bin/console messenger:consume scheduler_default --limit=10 --time-limit=86400


### PR DESCRIPTION
Add limit how many scheduler job to be processed before it exit to be restarted by process manager.