### PR TITLE
Chore: Optimize docker image size

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -10,34 +10,38 @@ RUN --mount=type=cache,target=/tmp/composer \
     --mount=type=cache,target=/app/node_modules \
     bin/build
 
-FROM docker.io/dunglas/frankenphp:1-php8.4-alpine AS runtime
-ARG S6_OVERLAY_VERSION=3.2.1.0
+FROM alpine AS runtime
 
-COPY --from=docker.io/mlocati/php-extension-installer /usr/bin/install-php-extensions /usr/local/bin/
+ARG FRANKENPHP_VERSION=1.11.2
+ARG S6_OVERLAY_VERSION=3.2.2.0
 
-RUN install-php-extensions imagick opcache zip
-
+# frankenphp provides static build that enough for our use case, no need to build our own version
+ADD https://github.com/php/frankenphp/releases/download/v${FRANKENPHP_VERSION}/frankenphp-linux-x86_64 /usr/local/bin/frankenphp
 ADD https://github.com/just-containers/s6-overlay/releases/download/v${S6_OVERLAY_VERSION}/s6-overlay-noarch.tar.xz /tmp
-RUN tar -C / -Jxpf /tmp/s6-overlay-noarch.tar.xz
 ADD https://github.com/just-containers/s6-overlay/releases/download/v${S6_OVERLAY_VERSION}/s6-overlay-x86_64.tar.xz /tmp
-RUN tar -C / -Jxpf /tmp/s6-overlay-x86_64.tar.xz
 
-COPY s6 /
+RUN mkdir -p /s6/root
+RUN tar -C /s6/root -Jxpf /tmp/s6-overlay-noarch.tar.xz
+RUN tar -C /s6/root -Jxpf /tmp/s6-overlay-x86_64.tar.xz
+RUN chmod +x /usr/local/bin/frankenphp
+COPY s6 /s6/root
 
-# Rebuild image to remove incorrect information such as EXPOSE, HEALTHCHECK etc.
-# https://stackoverflow.com/a/72024605
-FROM scratch
+FROM alpine
 
 # Fix permission for frankenphp to manage their data and config
 # https://github.com/php/frankenphp/issues/607#issuecomment-2690469396
 ENV XDG_CONFIG_HOME=/config
 ENV XDG_DATA_HOME=/data
 
-COPY --from=runtime / /
+COPY --from=runtime /s6/root /
+COPY --from=runtime /usr/local/bin/frankenphp /usr/local/bin/frankenphp
 COPY --from=builder /app/build/manga-server /app
 
-RUN mkdir -p /{config,data} \
-    && chown -R 1000:1000 /app /data /config
+RUN apk add --no-cache curl
+
+RUN mkdir /config \
+  && mkdir /data \
+  && chown -R 1000:1000 /app /data /config
 
 USER 1000:1000
 WORKDIR /app

--- a/s6/etc/s6-overlay/s6-rc.d/cache/up
+++ b/s6/etc/s6-overlay/s6-rc.d/cache/up
@@ -1,2 +1,2 @@
 #!/command/with-contenv sh
-php /app/bin/console cache:clear
+frankenphp php-cli /app/bin/console cache:clear

--- a/s6/etc/s6-overlay/s6-rc.d/initialize/up
+++ b/s6/etc/s6-overlay/s6-rc.d/initialize/up
@@ -1,2 +1,2 @@
 #!/command/with-contenv sh
-php /app/bin/console app:initialize
+frankenphp php-cli /app/bin/console app:initialize

--- a/s6/etc/s6-overlay/s6-rc.d/messenger/up
+++ b/s6/etc/s6-overlay/s6-rc.d/messenger/up
@@ -1,2 +1,2 @@
 #!/command/with-contenv sh
-php /app/bin/console messenger:setup-transports
+frankenphp php-cli /app/bin/console messenger:setup-transports

--- a/s6/etc/s6-overlay/s6-rc.d/scheduler/run
+++ b/s6/etc/s6-overlay/s6-rc.d/scheduler/run
@@ -1,2 +1,2 @@
 #!/command/with-contenv sh
-php /app/bin/console messenger:consume scheduler_default --limit=10 --time-limit=86400
+frankenphp php-cli /app/bin/console messenger:consume scheduler_default --limit=10 --time-limit=86400

--- a/s6/etc/s6-overlay/s6-rc.d/worker/run
+++ b/s6/etc/s6-overlay/s6-rc.d/worker/run
@@ -1,2 +1,2 @@
 #!/command/with-contenv sh
-php /app/bin/console messenger:consume async --limit=10 --time-limit=600
+frankenphp php-cli /app/bin/console messenger:consume async --limit=10 --time-limit=600


### PR DESCRIPTION
Close GH-297

Reduce docker image size by using static build of frankenphp. To make the build faster we use github release artifact instead compiling ourself.