### PR TITLE
Chore: Update php-cs-fixer to version 3.94.1

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -8,9 +8,6 @@ on:
         branches:
             - master
 
-env:
-    PHP_CS_FIXER_IGNORE_ENV: 1
-
 jobs:
     build:
         runs-on: ubuntu-latest

--- a/.php-cs-fixer.dist.php
+++ b/.php-cs-fixer.dist.php
@@ -14,4 +14,5 @@ return $config->setRules([
 ])
     ->setFinder($finder)
     ->setRiskyAllowed(true)
+    ->setUnsupportedPhpVersionAllowed(true)
 ;

--- a/devenv.nix
+++ b/devenv.nix
@@ -15,7 +15,6 @@ in
 {
   # https://devenv.sh/basics/
   env.OVERMIND_SKIP_ENV = true;
-  env.PHP_CS_FIXER_IGNORE_ENV = 1;
 
   # https://devenv.sh/packages/
   packages = [

--- a/phive.xml
+++ b/phive.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <phive xmlns="https://phar.io/phive">
-  <phar name="php-cs-fixer" version="^3.15.1" installed="3.75.0" location="./tools/php-cs-fixer" copy="false"/>
+  <phar name="php-cs-fixer" version="^3.15.1" installed="3.94.1" location="./tools/php-cs-fixer" copy="false"/>
   <phar name="infection" version="^0.27.7" installed="0.27.8" location="./tools/infection" copy="false"/>
 </phive>

--- a/src/Controller/ArchiveController.php
+++ b/src/Controller/ArchiveController.php
@@ -30,8 +30,8 @@ class ArchiveController extends AbstractController
     #[Route(
         '/archive/{path}',
         name: 'app_archive_list',
-        requirements: ['path' => '.+\.(zip|cbz|epub)$'], methods: ['GET'])
-    ]
+        requirements: ['path' => '.+\.(zip|cbz|epub)$'],
+        methods: ['GET'])]
     public function archiveListing(
         Request $request,
         DirectoryListing $listing,
@@ -58,8 +58,7 @@ class ArchiveController extends AbstractController
     #[Route(
         '/archive/{archive_item}',
         name: 'app_archive_item',
-        requirements: ['archive_item' => '.+\.(zip|cbz|epub\/).+$'])
-    ]
+        requirements: ['archive_item' => '.+\.(zip|cbz|epub\/).+$'])]
     public function archiveItem(Request $request, MimeGuesser $guesser): Response
     {
         $path = $request->attributes->get('archive_item');


### PR DESCRIPTION
Fix configuration to use unsupportedPhpVersionAllowed instead of setting PHP_CS_FIXER_IGNORE_ENV environment variable.