### PR TITLE
Chore: Replace pre-commit[1] with prek[2]

### DIFF
--- a/devenv.nix
+++ b/devenv.nix
@@ -33,6 +33,7 @@ in
   };
 
   # https://devenv.sh/pre-commit-hooks/
+  git-hooks.package = pkgs.prek;
   git-hooks.hooks = {
     nixfmt.enable = true;
     prettier = {


### PR DESCRIPTION
[skip ci]

pre-commit require python while prek doesn't have dependencies. This changes is experimental that might/might not be reverted later on.

Ref:
1: https://github.com/pre-commit/pre-commit
2: https://github.com/j178/prek