### PR TITLE
Bugfix: Make stream response compatible with roadrunner

### DIFF
--- a/src/Controller/ArchiveController.php
+++ b/src/Controller/ArchiveController.php
@@ -75,11 +75,12 @@ class ArchiveController extends AbstractController
             throw $this->createNotFoundException();
         }
 
-        $response = new StreamedResponse(function () use ($inputStream) {
+        $response = new StreamedResponse(function () use ($inputStream, $za) {
             /** @var resource $outputStream */
             $outputStream = fopen('php://output', 'wb');
 
             stream_copy_to_stream($inputStream, $outputStream);
+            $za->close();
         });
 
         $headers = [
@@ -87,7 +88,6 @@ class ArchiveController extends AbstractController
         ];
         $response->headers->add($headers);
         $response->setExpires(new \DateTime('+1 week'));
-        $response->send();
 
         return $response;
     }


### PR DESCRIPTION
Supersede #308 

When accessing image from zip archive on roadrunner runtime the page will hang indefinitely. It turns out that roadrunner still waiting for content from stream_copy_to_stream. By closing the zip archive it will tell that no more content to be copied.